### PR TITLE
Bump Fastify Major Version to `5.x`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,6 @@ const fp = require('fastify-plugin')
 const plugin = require('./plugin')
 
 module.exports = fp(plugin, {
-  fastify: '4.x',
+  fastify: '5.x',
   name: 'oas-fastify'
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "fastify-plugin": "^4.5.1"
+        "fastify-plugin": "^5.0.0"
       },
       "devDependencies": {
         "node-test-github-reporter": "^1.1.3"
@@ -57,9 +57,10 @@
       }
     },
     "node_modules/fastify-plugin": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
-      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.0.tgz",
+      "integrity": "sha512-0725fmH/yYi8ugsjszLci+lLnGBK6cG+WSxM7edY2OXJEU7gr2JiGBoieL2h9mhTych1vFsEfXsAsGGDJ/Rd5w==",
+      "license": "MIT"
     },
     "node_modules/node-test-github-reporter": {
       "version": "1.1.10",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:ci": "npm run test:cli -- --test-reporter node-test-github-reporter test"
   },
   "dependencies": {
-    "fastify-plugin": "^4.5.1"
+    "fastify-plugin": "^5.0.0"
   },
   "devDependencies": {
     "node-test-github-reporter": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.0.0-semantically-released",
-  "name": "oas-fastify",
+  "version": "5.0.0",
+  "name": "@aurora-interactive/oas-fastify",
   "description": "OAS 3.x to Fastify routes automation",
   "author": "Ahmad Nassri <email@ahmadnassri.com> (https://www.ahmadnassri.com)",
   "homepage": "https://github.com/ahmadnassri/node-oas-fastify",


### PR DESCRIPTION
This PR adds support for Fastify `5.x`. Simply bumped the fastify-plugin version declaration. Thank you for your consideration.